### PR TITLE
Add option to override 32MiB on DESR/DVR models

### DIFF
--- a/newlib/libc/sys/ps2/crt0.S
+++ b/newlib/libc/sys/ps2/crt0.S
@@ -30,6 +30,9 @@
    .globl   _ps2sdk_libc_deinit_weak
    .type    _ps2sdk_libc_deinit_weak, @function
 
+   .weak _ps2sdk_memory_init
+   .type _ps2sdk_memory_init, @function
+
    .extern _InitSys
    .extern Exit
    .extern FlushCache
@@ -83,6 +86,16 @@ setupthread:
    # writeback data cache
    jal FlushCache  # FlushCache(0)
    move   $4, $0
+
+memory_init:
+   # Capability to override 32MiB on DESR/DVR models (weak)
+
+   la     $8, _ps2sdk_memory_init
+   beqz   $8, 1f
+   nop
+   jalr   $8      # _ps2sdk_memory_init()
+   nop
+1:
 
 parseargs:
    # call ps2sdk argument parsing (weak)


### PR DESCRIPTION
This adds an optional function to be called early in starting an elf file. This function can set 64MiB mode on DESR/DVR models. 

This replaces the current code (PR in ps2sdk shortly) that enables 64MiB by default for all applications. Enabling it by default is problematic becouse it makes applications behave differently on DESR than on any other ps2. This is not desirable since not many people have a DESR. Since these application are made for 32MiB and tested on 32MiB, there is no need to enable more memory.

With this change applications still have an easy way to use the extra memory.
Applications need to add the following code to use 64MiB:

```C
void _ps2sdk_memory_init()
{
    if (GetMemorySize() == (32 * 1024 * 1024) && IsDESRMachine() == 1) {
        // Switch to 64MiB mode
        SetMemoryMode(0);
        _InitTLB();
        // Restart application
        __start();
    }
}
```

Optionally this function can be put into a separate library in ps2sdk. Linking to this library will enable the use of 64MiB.