### PR TITLE
Force alignment for  _JBTYPE

### DIFF
--- a/newlib/libc/include/machine/setjmp.h
+++ b/newlib/libc/include/machine/setjmp.h
@@ -130,7 +130,7 @@ _BEGIN_STD_C
 #ifdef __mips__
 # if defined(__mips64)
 #  if defined(_MIPS_ARCH_R5900)
-    typedef unsigned int jbtype128 __attribute__(( mode(TI) ));
+    typedef unsigned int jbtype128 __attribute__((mode(TI))) __attribute__((aligned(16)));
 #   define _JBTYPE jbtype128
 #  else
 #   define _JBTYPE long long


### PR DESCRIPTION
After several hours investigating the issue with setjmp/longjmp it looks to be an alignment issue