### PR TITLE
Fix usage of `wait`, `fork`, adding `execve` and variants

### DIFF
--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -534,7 +534,7 @@ case "${host}" in
   mips*-ps2-*)
 	sys_dir=ps2
 	posix_dir=posix
-	newlib_cflags="${newlib_cflags} -G0 -DHAVE_NANOSLEEP -DHAVE_RENAME -DHAVE_FCNTL -D_NO_POSIX_SPAWN -D_NO_EXECVE -DNO_EXEC"
+	newlib_cflags="${newlib_cflags} -G0 -DHAVE_NANOSLEEP -DHAVE_RENAME -DHAVE_FCNTL -D_NO_POSIX_SPAWN"
 	;;
   mmix-knuth-mmixware)
 	sys_dir=mmixware


### PR DESCRIPTION
The content of the file `newlib/libc/reent/execr.c` wasn't compiled because we had defined the flag `NO_EXEC` skipping the compilation of `_execve_r`, `_fork_r` and `_wait_r`.

This PR requires also to merge: https://github.com/ps2dev/ps2sdk/pull/554

Cheers.