### PR TITLE
Define properly _CLOCKS_PER_SEC

### DIFF
--- a/newlib/libc/sys/ps2/machine/time.h
+++ b/newlib/libc/sys/ps2/machine/time.h
@@ -1,0 +1,6 @@
+#ifndef	_MACHTIME_H_
+#define	_MACHTIME_H_
+
+#define _CLOCKS_PER_SEC_ 1000000
+
+#endif	/* _MACHTIME_H_ */


### PR DESCRIPTION
Newlib by default defines `CLOCKS_PER_SEC` as `1000` which is wrong,. it should be `1000000`.

Official info:
```
The clock() function conforms to ISO/IEC 9899:1990 (“ISO C90”) and Version 3 of the Single UNIX Specification (“SUSv3”) which requires CLOCKS_PER_SEC to be defined as one million.
```