### PR TITLE
Fix usage of lockAPI

### DIFF
--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -534,7 +534,7 @@ case "${host}" in
   mips*-ps2-*)
 	sys_dir=ps2
 	posix_dir=posix
-	newlib_cflags="${newlib_cflags} -G0 -DHAVE_NANOSLEEP -DHAVE_RENAME -DHAVE_FCNTL -D_NO_POSIX_SPAWN"
+	newlib_cflags="${newlib_cflags} -G0 -DHAVE_NANOSLEEP -DHAVE_RENAME -DHAVE_FCNTL -D_NO_POSIX_SPAWN -DHAVE_DD_LOCK"
 	;;
   mmix-knuth-mmixware)
 	sys_dir=mmixware

--- a/newlib/libc/misc/lock.c
+++ b/newlib/libc/misc/lock.c
@@ -81,7 +81,9 @@ subroutines are required for linking multi-threaded applications.
 
 /* dummy lock routines and static locks for single-threaded apps */
 
-#ifndef __SINGLE_THREAD__
+#include <newlib.h>
+
+#if defined(__SINGLE_THREAD__)
 
 #include <sys/lock.h>
 

--- a/newlib/libc/sys/ps2/sys/dirent.h
+++ b/newlib/libc/sys/ps2/sys/dirent.h
@@ -8,6 +8,7 @@ typedef struct __dirdesc {
     char *dd_buf;	/* buffer */
     int dd_len;		/* buffer length */
     int dd_size;	/* amount of data in buffer */
+    void *dd_lock;	/* lock */
 } DIR;
 
 # define __dirfd(dp)	((dp)->dd_fd)


### PR DESCRIPTION
To have thread-safe operations for all the `newlib` operations we have been required to do several PR:

- [`newlib`](https://github.com/ps2dev/newlib/pull/13)
- [`ps2toolchain-ee`](https://github.com/ps2dev/ps2toolchain-ee/pull/44)
- [`ps2sdk`](https://github.com/ps2dev/ps2sdk/pull/592)

This PR skips the usage of the dummy lock API, letting us implement the specific one in the `ps2sdk/libcglue`