### PR TITLE
Fix build with gcc14

### DIFF
--- a/newlib/libc/include/sys/lock.h
+++ b/newlib/libc/include/sys/lock.h
@@ -41,7 +41,7 @@ typedef struct __lock * _LOCK_T;
 extern void __retarget_lock_init(_LOCK_T *lock);
 #define __lock_init(lock) __retarget_lock_init(&lock)
 extern void __retarget_lock_init_recursive(_LOCK_T *lock);
-#define __lock_init_recursive(lock) __retarget_lock_init_recursive(&lock)
+#define __lock_init_recursive(lock) __retarget_lock_init_recursive((_LOCK_T*)&lock)
 extern void __retarget_lock_close(_LOCK_T lock);
 #define __lock_close(lock) __retarget_lock_close(lock)
 extern void __retarget_lock_close_recursive(_LOCK_T lock);

--- a/newlib/libc/include/sys/stat.h
+++ b/newlib/libc/include/sys/stat.h
@@ -142,7 +142,7 @@ int	mkfifo (const char *__path, mode_t __mode );
 int	stat (const char *__restrict __path, struct stat *__restrict __sbuf );
 mode_t	umask (mode_t __mask );
 
-#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__)
+#if defined (__SPU__) || defined(__rtems__) || defined(__CYGWIN__) || defined(__ps2sdk__)
 int	lstat (const char *__restrict __path, struct stat *__restrict __buf );
 int	mknod (const char *__path, mode_t __mode, dev_t __dev );
 #endif


### PR DESCRIPTION
Enables the lstat definiton on ps2sdk using a gcc builtin platform macro.

The workaround patch is hopefully temporary.